### PR TITLE
Fix firefox compatibility with comments testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ and selenium libraties to run automated tests.
 
 ### How to run automated tests?
 
-1. You need to download the latest version of webdriver executable to run tests.
-Check **[selenium official website](http://docs.seleniumhq.org/download/)** 
-`Third Party Browser Drivers` for latest versions of browser that you need.
-2. Then launch it and run command `pytest comments` from terminal within your 
-virtual environment.
+1. Download the latest version of Selenium Standalone Server from 
+**[selenium official website](http://docs.seleniumhq.org/download/)**.
+2. Launch selenium server using command `java -jar 
+selenium-server-standalone-3.4.0.jar`. Name of the jar file can be different 
+if you get later version of Selenium Server.
+3. Run command `pytest comments` from terminal within your virtual environment.
 
 
 ### Tests samples

--- a/comments/core/tools/property_reader.py
+++ b/comments/core/tools/property_reader.py
@@ -10,6 +10,6 @@ class PropertyReader(object):
         self._config.read(self._config_file)
         return self._config.get('browser settings', 'browser')
 
-    def get_host(self) -> str:
+    def get_executor(self) -> str:
         self._config.read(self._config_file)
-        return self._config.get('browser settings', 'browser_port')
+        return self._config.get('browser settings', 'executor')

--- a/comments/core/tools/webdriver_utils.py
+++ b/comments/core/tools/webdriver_utils.py
@@ -68,19 +68,21 @@ class RemoteDriver(Driver):
 class WebDriverFactoryFromConfig:
     def init_driver(self):
         browser_name = PropertyReader('config.properties').get_browser_name()
-        port = PropertyReader('config.properties').get_host()
+        executor = PropertyReader('config.properties').get_executor()
 
         if browser_name.lower() == "chrome":
             try:
-                capabilities = DesiredCapabilities.CHROME.copy()
-                driver = webdriver.Remote(port, capabilities)
+                driver = webdriver.Remote(
+                    command_executor=executor,
+                    desired_capabilities=DesiredCapabilities.CHROME)
                 return RemoteDriver(driver)
             except Exception:
                 raise Exception("Can't initialize webdriver")
         elif browser_name.lower() == "firefox":
             try:
-                capabilities = DesiredCapabilities.FIREFOX.copy()
-                driver = webdriver.Remote(port, capabilities)
+                driver = webdriver.Remote(
+                    command_executor=executor,
+                    desired_capabilities=DesiredCapabilities.FIREFOX)
                 return RemoteDriver(driver)
             except Exception:
                 raise Exception("Can't initialize webdriver")

--- a/config.properties
+++ b/config.properties
@@ -1,3 +1,3 @@
 [browser settings]
 browser = chrome
-browser_port = http://localhost:9515
+executor = http://127.0.0.1:4444/wd/hub


### PR DESCRIPTION
Firefox geckodriver(versions 14,15,16,17,18) is unable to launch firefox driver and perform all tests properly. Therefore launching a browser via Selenium Server was implemented to solve this problem.
What was done:
- Modified config.properties
- `init_driver()` in WedDriverFactoryFromConfig was modified
- Updated README.md